### PR TITLE
Maintain project relative paths of 3d files

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ logger = logging.getLogger()
 
 def download_part(lcsc_id, dir):
     os.makedirs(os.path.dirname(dir), exist_ok=True)
-    easyeda2kicad.main(["--full", f"--lcsc_id={lcsc_id}", "--output", dir, "--overwrite"])
+    easyeda2kicad.main(["--full", f"--lcsc_id={lcsc_id}", "--output", dir, "--overwrite", "--project-relative"])
 
 
 class Plugin(pcbnew.ActionPlugin):
@@ -52,7 +52,8 @@ class Dialog(wx.Dialog):
         )
 
         board = pcbnew.GetBoard()
-        download_dir = f"{os.path.dirname(board.GetFileName())}/libs/easyeda/easyeda"
+        os.chdir(os.path.dirname(board.GetFileName()))
+        download_dir = "./libs/easyeda/easyeda"
 
         content = wx.BoxSizer(wx.VERTICAL)
 


### PR DESCRIPTION
Currently when entire project is moved around the 3d file references break as they have absolute paths.
